### PR TITLE
feat: build docker use current code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -y install libmysqlclient-dev libssl-dev
 # For PostgreSQL support
 RUN apt-get -y install libpq-dev
 
-RUN git clone https://github.com/akopytov/sysbench.git sysbench
+ADD . sysbench
 
 WORKDIR sysbench
 RUN ./autogen.sh


### PR DESCRIPTION
### Summary

Replace `RUN git clone` with `ADD . sysbench` to build the Docker image with local code. This change simplifies testing of local modifications.